### PR TITLE
Log name of package when uninstalling extensions

### DIFF
--- a/DNN Platform/Library/Services/Upgrade/Upgrade.cs
+++ b/DNN Platform/Library/Services/Upgrade/Upgrade.cs
@@ -3207,6 +3207,8 @@ namespace DotNetNuke.Services.Upgrade
 
         private static void UninstallPackage(string packageName, string packageType, bool deleteFiles = true, string version = "")
         {
+	    DnnInstallLogger.InstallLogInfo(string.Concat(Localization.Localization.GetString("LogStart", Localization.Localization.GlobalResourceFile), "Package:", packageName, " Type:", packageType, " Version:", version));
+	    
             var searchInput = PackageController.Instance.GetExtensionPackage(Null.NullInteger, p => 
                 p.Name.Equals(packageName, StringComparison.OrdinalIgnoreCase) 
                 && p.PackageType.Equals(packageType, StringComparison.OrdinalIgnoreCase)


### PR DESCRIPTION


## Summary
When the platform is uninstalling extensions, it doesn't log when and what extensions were uninstalled as part of the upgrade process.

Hopefully this will help troubleshoot similar issues like #2552